### PR TITLE
Add FlameFrags

### DIFF
--- a/kustomize/base/config/servers.yaml
+++ b/kustomize/base/config/servers.yaml
@@ -222,6 +222,8 @@ java:
     address: "playskyward.gg"
   - name: "BlockHero"
     address: "play.blockhero.net"
+  - name: "FlameFrags"
+    address: "play.flamefrags.com"
 bedrock:
   - name: "Mineville"
     address: "play.inpvp.net"


### PR DESCRIPTION
FlameFrags is an Eastern NA network focusing on SMP and Duels/practice gamemodes, with playercounts averaging 200+ each day and a 30d peak of 428. No spoofing or botting is used, and users are hard-capped on accounts per IP (with proxy/VPN mitigation in place). The server has grown consistently over the past 8mo+ since it's launch.

Data screenshot provided from our internal Grafana instance of playercount over the last 30d:
![Aka2SIuwoFdMOXpZ](https://github.com/user-attachments/assets/7cd8ec26-d386-49f4-94c3-aee5aa54383a)

[Store Page](https://flamefrags.com/)